### PR TITLE
fix(table): Add Sort for hidden columns

### DIFF
--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -40,27 +40,22 @@ export class App {
   constructor(private _options) {}
 
   activate(): void {
-    setTimeout(() => {
-      const _items = [];
-      for (let i = 0; i < 500; i++) {
-        const randomYear = 2000 + Math.floor(Math.random() * 10);
-        const randomMonth = Math.floor(Math.random() * 11);
-        const randomDay = Math.floor(Math.random() * 29);
-        const randomPercent = Math.round(Math.random() * 100);
+    for (let i = 0; i < 500; i++) {
+      const randomYear = 2000 + Math.floor(Math.random() * 10);
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor(Math.random() * 29);
+      const randomPercent = Math.round(Math.random() * 100);
 
-        _items[i] = {
-          id: i,
-          title: "Task " + i,
-          duration: Math.round(Math.random() * 100) + "",
-          percentComplete: randomPercent,
-          start: i === 465 ? "1990-01-01" : `${randomYear}-${randomMonth}-${randomDay}`,
-          finish: `${randomYear}-${randomMonth}-${randomDay}`,
-          effortDriven: i % 5 === 0
-        };
-      }
-
-      this.allItems = _items;
-    }, 2000);
+      this.allItems[i] = {
+        id: i,
+        title: "Task " + i,
+        duration: Math.round(Math.random() * 100) + "",
+        percentComplete: randomPercent,
+        start: `${randomYear}-${randomMonth}-${randomDay}`,
+        finish: `${randomYear}-${randomMonth}-${randomDay}`,
+        effortDriven: i % 5 === 0
+      };
+    }
   }
 
   changeFramework(framework: string): void {

--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -23,7 +23,11 @@ export class App {
       field: "percentComplete"
     },
     {
-      field: "start"
+      field: "start",
+      hidden: true,
+      sort: {
+        direction: "asc"
+      }
     },
     {
       field: "finish"
@@ -36,22 +40,27 @@ export class App {
   constructor(private _options) {}
 
   activate(): void {
-    for (let i = 0; i < 500; i++) {
-      const randomYear = 2000 + Math.floor(Math.random() * 10);
-      const randomMonth = Math.floor(Math.random() * 11);
-      const randomDay = Math.floor(Math.random() * 29);
-      const randomPercent = Math.round(Math.random() * 100);
+    setTimeout(() => {
+      const _items = [];
+      for (let i = 0; i < 500; i++) {
+        const randomYear = 2000 + Math.floor(Math.random() * 10);
+        const randomMonth = Math.floor(Math.random() * 11);
+        const randomDay = Math.floor(Math.random() * 29);
+        const randomPercent = Math.round(Math.random() * 100);
 
-      this.allItems[i] = {
-        id: i,
-        title: "Task " + i,
-        duration: Math.round(Math.random() * 100) + "",
-        percentComplete: randomPercent,
-        start: `${randomYear}-${randomMonth}-${randomDay}`,
-        finish: `${randomYear}-${randomMonth}-${randomDay}`,
-        effortDriven: i % 5 === 0
-      };
-    }
+        _items[i] = {
+          id: i,
+          title: "Task " + i,
+          duration: Math.round(Math.random() * 100) + "",
+          percentComplete: randomPercent,
+          start: i === 465 ? "1990-01-01" : `${randomYear}-${randomMonth}-${randomDay}`,
+          finish: `${randomYear}-${randomMonth}-${randomDay}`,
+          effortDriven: i % 5 === 0
+        };
+      }
+
+      this.allItems = _items;
+    }, 2000);
   }
 
   changeFramework(framework: string): void {

--- a/src/elements/phd-table.ts
+++ b/src/elements/phd-table.ts
@@ -162,8 +162,7 @@ export class PhdTableCustomElement<T> {
         header:
           !c.header && typeof c.field === "string"
             ? toTitleCase(c.field)
-            : c.header,
-        sort: c.sort ? { ...c.sort, field: c.field } : c.sort
+            : c.header
       }));
 
     this.optionsChanged();
@@ -247,7 +246,11 @@ export class PhdTableCustomElement<T> {
   }
 
   _sort(): void {
-    this._sorts = this._columns
+    this._sorts = this.columns
+      .map(c => ({
+        ...c,
+        sort: c.sort ? { ...c.sort, field: c.field } : c.sort
+      }))
       .filter(c => c.sort)
       .map(c => c.sort)
       .sort((a, b) => a.order - b.order);


### PR DESCRIPTION
Prior code was using `_columns`, which filtered out `hidden`.
Let `_sort` method manipulate `columns` directly. Could get messy if
each method relies on another method to do its work, as the code
originally did in the `columnsChanged` method

closes #3