### PR TITLE
feat(table): Add row-selection-changed event

### DIFF
--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -11,6 +11,8 @@ const authors = ["John", "Ben", "Sam", "Tom", "Luke", "Ike", "Hayes", "Lee"];
 @inject("defaultOptions")
 export class App {
   allItems = [];
+  rows = [];
+  _filteredItems = [];
   _authors = authors;
   _searchForm = {};
 
@@ -89,6 +91,12 @@ export class App {
     }
   ];
 
+  _tableOptions = {
+    selection: {
+      highlightOnSelect: true
+    }
+  };
+
   constructor(private _options) {
     this._resetFilter();
   }
@@ -148,6 +156,15 @@ export class App {
 
       return accu;
     }, {});
+  }
+
+  _filterRows(filteredItems: any[]): void {
+    this.rows = filteredItems.map(item => ({
+      item,
+      selected: true
+    }));
+
+    this._filteredItems = filteredItems;
   }
 }
 

--- a/dev-app/bootstrap3.html
+++ b/dev-app/bootstrap3.html
@@ -13,7 +13,7 @@
       <phd-search-bar
         filter.bind="_searchFilter"
         items.bind="allItems"
-        filtered.delegate="_filteredItems=$event.detail.filteredItems"
+        filtered.delegate="_filterRows($event.detail.filteredItems)"
       >
         <div class="form-group">
           <label>Title</label>
@@ -63,9 +63,10 @@
         </button>
       </phd-search-bar>
       <phd-table
-        items.bind="_filteredItems"
+        rows.bind="rows"
         columns.bind="_itemColumns"
         page.bind="itemPage"
+        options.bind="_tableOptions"
       >
       </phd-table>
       <phd-pager

--- a/dev-app/bulma.html
+++ b/dev-app/bulma.html
@@ -13,7 +13,7 @@
       <phd-search-bar
         filter.bind="_searchFilter"
         items.bind="allItems"
-        filtered.delegate="_filteredItems=$event.detail.filteredItems"
+        filtered.delegate="_filterRows($event.detail.filteredItems)"
       >
         <div class="field">
           <label class="label">Title</label>
@@ -72,9 +72,10 @@
         </div>
       </phd-search-bar>
       <phd-table
-        items.bind="_filteredItems"
+        rows.bind="rows"
         columns.bind="_itemColumns"
         page.bind="itemPage"
+        options.bind="_tableOptions"
       >
       </phd-table>
       <phd-pager

--- a/src/elements/bootstrap3/cell-selector.html
+++ b/src/elements/bootstrap3/cell-selector.html
@@ -1,12 +1,3 @@
-<template bindable="row, item">
-  <div class="checkbox">
-    <label for="select${row.index}">
-      <input
-        id="select${row.index}"
-        type="checkbox"
-        checked.bind="row.selected"
-        model.bind="item"
-      />
-    </label>
-  </div>
+<template bindable="row, index">
+  <input id="select${index}" type="checkbox" checked.bind="row.selected" />
 </template>

--- a/src/elements/bootstrap3/header-selector.html
+++ b/src/elements/bootstrap3/header-selector.html
@@ -1,10 +1,7 @@
 <template bindable="row">
-  <div class="checkbox">
-    <input
-      id="select${row.index}"
-      type="checkbox"
-      checked.bind="row.selected"
-      model.bind="item"
-    />
-  </div>
+  <input
+    id="phdtable-selectAllRows"
+    type="checkbox"
+    checked.bind="row.selected"
+  />
 </template>

--- a/src/elements/bootstrap3/phd-table.html
+++ b/src/elements/bootstrap3/phd-table.html
@@ -32,7 +32,7 @@
           <cell-selector
             row.bind="row"
             index.bind="$index"
-            change.delegate="_rowSelectionChanged($event, [ row ], row.selected)"
+            change.delegate="_rowSelectionChanged($event, [ row ])"
           ></cell-selector>
         </td>
         <td

--- a/src/elements/bootstrap3/phd-table.html
+++ b/src/elements/bootstrap3/phd-table.html
@@ -6,10 +6,10 @@
   <table class="table table-hoverable">
     <thead>
       <tr>
-        <th width="0px" show.bind="options.selectable">
+        <th width="0px" show.bind="options.selection">
           <header-selector
             row.bind="_headerRow"
-            click.delegate="_selectAllRows()"
+            change.delegate="_selectAllRows($event)"
           ></header-selector>
         </th>
         <th repeat.for="column of _columns">
@@ -25,12 +25,14 @@
     </thead>
     <tbody>
       <tr
-        repeat.for="row of _rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
+        repeat.for="row of rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
+        class="${options.selection.highlightOnSelect && row.selected ? 'active' : ''}"
       >
-        <td show.bind="options.selectable">
+        <td show.bind="options.selection">
           <cell-selector
-            row.bind="{ index: $index, selected: selectedItems }"
-            item.bind="row.item"
+            row.bind="row"
+            index.bind="$index"
+            change.delegate="_rowSelectionChanged($event, [ row ], row.selected)"
           ></cell-selector>
         </td>
         <td
@@ -48,7 +50,7 @@
       </tr>
     </tbody>
   </table>
-  <div show.bind="!items.length">
+  <div show.bind="!rows.length">
     <no-items-area></no-items-area>
   </div>
 </template>

--- a/src/elements/bulma/cell-selector.html
+++ b/src/elements/bulma/cell-selector.html
@@ -1,12 +1,11 @@
-<template bindable="row, item">
+<template bindable="row, index">
   <div class="field">
     <input
       class="is-checkradio is-small"
-      id="select${row.index}"
+      id="select${index}"
       type="checkbox"
       checked.bind="row.selected"
-      model.bind="item"
     />
-    <label for="select${row.index}"></label>
+    <label for="select${index}"></label>
   </div>
 </template>

--- a/src/elements/bulma/header-selector.html
+++ b/src/elements/bulma/header-selector.html
@@ -1,7 +1,7 @@
 <template bindable="row">
   <input
     class="is-checkradio is-small"
-    id="selectAll"
+    id="phdtable-selectAllRows"
     type="checkbox"
     checked.bind="row.selected"
   />

--- a/src/elements/bulma/phd-table.html
+++ b/src/elements/bulma/phd-table.html
@@ -35,7 +35,7 @@
           <cell-selector
             row.bind="row"
             index.bind="$index"
-            change.delegate="_rowSelectionChanged($event, [ row ], row.selected)"
+            change.delegate="_rowSelectionChanged($event, [ row ])"
           ></cell-selector>
         </td>
         <td

--- a/src/elements/bulma/phd-table.html
+++ b/src/elements/bulma/phd-table.html
@@ -6,10 +6,10 @@
   <table class="table is-striped is-hoverable is-fullwidth">
     <thead>
       <tr>
-        <th width="0px" show.bind="options.selectable">
+        <th width="0px" show.bind="options.selection">
           <header-selector
             row.bind="_headerRow"
-            click.delegate="_selectAllRows()"
+            change.delegate="_selectAllRows($event)"
           ></header-selector>
         </th>
         <th repeat.for="column of _columns">
@@ -28,12 +28,14 @@
     </thead>
     <tbody>
       <tr
-        repeat.for="row of _rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
+        repeat.for="row of rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
+        class="${options.selection.highlightOnSelect && row.selected ? 'is-selected' : ''}"
       >
-        <td show.bind="options.selectable">
+        <td show.bind="options.selection">
           <cell-selector
-            row.bind="{ index: $index, selected: selectedItems }"
-            item.bind="row.item"
+            row.bind="row"
+            index.bind="$index"
+            change.delegate="_rowSelectionChanged($event, [ row ], row.selected)"
           ></cell-selector>
         </td>
         <td
@@ -52,7 +54,7 @@
     </tbody>
   </table>
 
-  <div show.bind="!items.length">
+  <div show.bind="!rows.length">
     <no-items-area></no-items-area>
   </div>
 </template>

--- a/src/elements/phd-table.ts
+++ b/src/elements/phd-table.ts
@@ -79,7 +79,7 @@ export class PhdTableCustomElement<T> {
   /**
    * @deprecated use selected property on row object
    */
-  @bindable selectedItems: T[] = [];
+  @bindable selectedItems: T[];
   @bindable rows: RowData<T>[];
 
   _$nestedTableCell: HTMLTableCellElement;
@@ -206,6 +206,8 @@ export class PhdTableCustomElement<T> {
         "selected items is deprecated. use the selected property on the row"
       );
     }
+
+    this.selectedItems = this.selectedItems || [];
   }
 
   _cellClicked($event: MouseEvent, args: CellClickedArgs<T>): boolean {
@@ -353,7 +355,9 @@ export class PhdTableCustomElement<T> {
         bubbles: true,
         detail: {
           $event,
-          selection: rows.map(row => ({ row, column: null }))
+          selection: rows
+            .filter(r => r.selected)
+            .map(row => ({ row, column: null }))
         }
       })
     );

--- a/src/elements/phd-table.ts
+++ b/src/elements/phd-table.ts
@@ -355,7 +355,7 @@ export class PhdTableCustomElement<T> {
         bubbles: true,
         detail: {
           $event,
-          selection: rows
+          selection: this.rows
             .filter(r => r.selected)
             .map(row => ({ row, column: null }))
         }

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,7 +2,8 @@ export type SortDirection = "asc" | "desc" | "";
 
 export interface RowData<T> {
   item: T;
-  expanded: boolean;
+  expanded?: boolean;
+  selected?: boolean;
 }
 
 export interface Header {
@@ -35,12 +36,25 @@ export interface Column {
   className?: string;
 }
 
+export interface SelectionOption {
+  highlightOnSelect: boolean;
+}
+
 export interface Options {
+  /**
+   * @deprecated use selection property instead
+   */
   selectable?: boolean;
+  selection?: boolean | Partial<SelectionOption>;
 }
 
 export interface CellClickedArgs<T> {
   row: RowData<T>;
+}
+
+export interface RowEvent<T> {
+  row: RowData<T>;
+  column: Column;
 }
 
 export interface HeaderClickedArgs {


### PR DESCRIPTION
* DEPRECATE `selectedItems`, use `row.selected` & `options.selection`
* DEPRECATE `items`, use `rows`
* DEPRECATE table `options.selectable`, use table `options.selection`
* FIX bootstrap3 selection checkbox, divs made inputs not aligned
* FEAT add table `options.highlightOnSelect`
* FEAT add RowEvent for row-selection-changed event
