### PR TITLE
feat(table): Add selection to any column

### DIFF
--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -59,6 +59,10 @@ export class App {
 
   _itemColumns: ExtendedColumn[] = [
     {
+      selection: true,
+      renderer: ({ row }) => (row.selected ? "&#x2714;" : "")
+    },
+    {
       field: "id"
     },
     {
@@ -134,22 +138,24 @@ export class App {
   }
 
   _resetFilter(): void {
-    this._searchFilter = this._itemColumns.map<Filter>(i => {
-      const fields = Array.isArray(i.field) ? i.field : [i.field];
-      const header: string =
-        i.header && ((i.header as Header).name || (i.header as string));
-      const display =
-        header || (!Array.isArray(i.field) ? i.field : i.field[0]);
+    this._searchFilter = this._itemColumns
+      .filter(i => !i.selection)
+      .map<Filter>(i => {
+        const fields = Array.isArray(i.field) ? i.field : [i.field];
+        const header: string =
+          i.header && ((i.header as Header).name || (i.header as string));
+        const display =
+          header || (!Array.isArray(i.field) ? i.field : i.field[0]);
 
-      return {
-        fields,
-        display,
-        values: (this._searchForm[display] === null
-          ? []
-          : this._searchForm[display] || i.filter || i.values || []
-        ).filter(v => v)
-      } as Filter;
-    });
+        return {
+          fields,
+          display,
+          values: (this._searchForm[display] === null
+            ? []
+            : this._searchForm[display] || i.filter || i.values || []
+          ).filter(v => v)
+        } as Filter;
+      });
 
     this._searchForm = this._searchFilter.reduce((accu, curr) => {
       accu[curr.display] = curr.values;
@@ -159,9 +165,9 @@ export class App {
   }
 
   _filterRows(filteredItems: any[]): void {
-    this.rows = filteredItems.map(item => ({
+    this.rows = filteredItems.map((item, idx) => ({
       item,
-      selected: true
+      selectable: idx % 3 === 0 ? true : false
     }));
 
     this._filteredItems = filteredItems;

--- a/src/attributes/enhance-html.ts
+++ b/src/attributes/enhance-html.ts
@@ -18,16 +18,19 @@ export class EnhanceHtmlCustomAttribute {
   }
 
   valueChanged(): void {
-    const factory = this._compiler.compile(
-      `<template>${this.value}</template>`,
-      this._resources
-    );
-    const view = factory.create(
-      this._view.container,
-      this._view.bindingContext
-    );
-
     this._slot.removeAll();
-    this._slot.add(view);
+
+    if (this.value) {
+      const factory = this._compiler.compile(
+        `<template>${this.value}</template>`,
+        this._resources
+      );
+      const view = factory.create(
+        this._view.container,
+        this._view.bindingContext
+      );
+
+      this._slot.add(view);
+    }
   }
 }

--- a/src/elements/bootstrap3/phd-table.html
+++ b/src/elements/bootstrap3/phd-table.html
@@ -2,19 +2,21 @@
   <require from="./header-selector.html"></require>
   <require from="./cell-selector.html"></require>
   <require from="./no-items-area.html"></require>
+  <require from="../phd-table.css"></require>
 
   <table class="table table-hoverable">
     <thead>
       <tr>
-        <th width="0px" show.bind="options.selection">
-          <header-selector
-            row.bind="_headerRow"
-            change.delegate="_selectAllRows($event)"
-          ></header-selector>
-        </th>
         <th repeat.for="column of _columns">
           <a click.delegate="_headerClicked({ $event, column })">
-            ${column.header.name || column.header}
+            <span show.bind="!column.header.template">
+              ${_renderHeader(column)}
+            </span>
+            <span
+              enhance-html="${_renderHeader(column)}"
+              show.bind="column.header.template"
+            >
+            </span>
             <span show.bind="column.sort">
               <span show.bind="column.sort.direction === 'asc'">&#9660;</span>
               <span show.bind="column.sort.direction === 'desc'">&#9650;</span>
@@ -28,24 +30,17 @@
         repeat.for="row of rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
         class="${options.selection.highlightOnSelect && row.selected ? 'active' : ''}"
       >
-        <td show.bind="options.selection">
-          <cell-selector
-            row.bind="row"
-            index.bind="$index"
-            change.delegate="_rowSelectionChanged($event, [ row ])"
-          ></cell-selector>
-        </td>
         <td
           repeat.for="column of _columns"
           class="${column.className}"
-          click.capture="_cellClicked($event, { row })"
+          click.capture="_cellClicked($event, { row, column })"
         >
           <span
-            if.bind="column.renderer"
+            if.bind="column.renderer({ column, row, item: row.item })"
             style.bind="column.style"
-            enhance-html="${column.renderer({ item: row.item })}"
+            enhance-html="${_render(row, column)}"
           ></span>
-          <span else>${_getFieldData(row.item, column)}</span>
+          <span else>${_render(row, column)}</span>
         </td>
       </tr>
     </tbody>

--- a/src/elements/bulma/cell-selector.html
+++ b/src/elements/bulma/cell-selector.html
@@ -1,11 +1,3 @@
 <template bindable="row, index">
-  <div class="field">
-    <input
-      class="is-checkradio is-small"
-      id="select${index}"
-      type="checkbox"
-      checked.bind="row.selected"
-    />
-    <label for="select${index}"></label>
-  </div>
+  <input id="select${index}" type="checkbox" checked.bind="row.selected" />
 </template>

--- a/src/elements/bulma/phd-table.html
+++ b/src/elements/bulma/phd-table.html
@@ -2,22 +2,24 @@
   <require from="./header-selector.html"></require>
   <require from="./cell-selector.html"></require>
   <require from="./no-items-area.html"></require>
+  <require from="../phd-table.css"></require>
 
   <table class="table is-striped is-hoverable is-fullwidth">
     <thead>
       <tr>
-        <th width="0px" show.bind="options.selection">
-          <header-selector
-            row.bind="_headerRow"
-            change.delegate="_selectAllRows($event)"
-          ></header-selector>
-        </th>
         <th repeat.for="column of _columns">
           <a
             click.delegate="_headerClicked({ $event, column })"
             class="has-text-dark"
           >
-            ${column.header.name || column.header}
+            <span show.bind="!column.header.template">
+              ${_renderHeader(column)}
+            </span>
+            <span
+              enhance-html="${_renderHeader(column)}"
+              show.bind="column.header.template"
+            >
+            </span>
             <span show.bind="column.sort" class="icon is-small is-right">
               <span show.bind="column.sort.direction === 'asc'">&#9660;</span>
               <span show.bind="column.sort.direction === 'desc'">&#9650;</span>
@@ -31,29 +33,21 @@
         repeat.for="row of rows | phdSort:_sorts | phdPage:page.size:page.pageNumber"
         class="${options.selection.highlightOnSelect && row.selected ? 'is-selected' : ''}"
       >
-        <td show.bind="options.selection">
-          <cell-selector
-            row.bind="row"
-            index.bind="$index"
-            change.delegate="_rowSelectionChanged($event, [ row ])"
-          ></cell-selector>
-        </td>
         <td
           repeat.for="column of _columns"
           class="${column.className}"
-          click.capture="_cellClicked($event, { row })"
+          click.capture="_cellClicked($event, { row, column })"
         >
           <span
-            if.bind="column.renderer"
+            if.bind="column.renderer({ column, row, item: row.item })"
             style.bind="column.style"
-            enhance-html="${column.renderer({ item: row.item })}"
+            enhance-html="${_render(row, column)}"
           ></span>
-          <span else>${_getFieldData(row.item, column)}</span>
+          <span else>${_render(row, column)}</span>
         </td>
       </tr>
     </tbody>
   </table>
-
   <div show.bind="!rows.length">
     <no-items-area></no-items-area>
   </div>

--- a/src/elements/phd-table.scss
+++ b/src/elements/phd-table.scss
@@ -1,0 +1,4 @@
+cell-selector,
+header-selector {
+  margin-right: 12px;
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,6 +9,7 @@ export interface RowData<T> {
 
 export interface Header {
   name: string;
+  template: string;
 }
 
 export interface Page {

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,6 +4,7 @@ export interface RowData<T> {
   item: T;
   expanded?: boolean;
   selected?: boolean;
+  selectable?: boolean;
 }
 
 export interface Header {
@@ -26,12 +27,27 @@ export interface Sort {
 }
 
 export interface Column {
-  header?: Header | string;
+  header?: Partial<Header> | string;
   hidden?: boolean;
   field?: string | string[];
   sort?: Sort;
-  renderer?: <T>({ item }: { item: T }) => string;
+  renderer?: <T>({
+    column,
+    row,
+    item
+  }: {
+    column?: Column;
+    row?: RowData<T>;
+    item?: T;
+  }) => string;
   formatter?: <T>({ item }: { item: T }) => string;
+  /**
+   * Marks the column as a selection column, rendering a checkbox along with any
+   * custom markup provided in the column through the field, renderer or formatter
+   * properties
+   *
+   */
+  selection?: boolean;
   style?: { [key: string]: string };
   className?: string;
 }


### PR DESCRIPTION
* Add a `selectable` property to the `Column` interface so there can be
  a mix of selectable and non-selectable columns. Default to `true`
* Move cell/header custom element to view model logic
* Render checkbox plus column data is available
  * Move all render logic into the view model to simplify
    finding the correct method to renderer the text
* Optimization - Do not enhance empty renderer result
  * Use the return type from `renderer` as the logic to determine if a
    template should be rendered
* Pass column and row to the column `renderer` in addition to the item.
* Remove `div` from bulma checkboxes since it will put any additional
  content on a new line, and we want them aligned
  * Pad right the checkbox so the user's data is identifiable
* FIX: Show an empty header when no header or field is provided
  * This will allow a selection column to have nothing as the header
* FIX: Check if sort property exists when header is clicked to determine
  if we should sort, but always bubble event. Also check if the
  selection box was checked so we do not sort.

fixes [AB#4701](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4701)