### PR TITLE
feat(search-bar): Add a search bar filters object

### DIFF
--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -1,12 +1,8 @@
-import { inject } from "aurelia-framework";
+import { inject, PLATFORM } from "aurelia-framework";
 import { Filter, Column, Header } from "resources";
-import { PLATFORM } from "aurelia-framework";
-
-interface ExtendedColumn extends Column {
-  [x: string]: any;
-}
 
 type SearchFilters = import("resources").SearchFilters;
+type FilterEventDetail = import("resources").FilterEventDetail;
 
 const authors = ["John", "Ben", "Sam", "Tom", "Luke", "Ike", "Hayes", "Lee"];
 
@@ -16,8 +12,6 @@ export class App {
   rows = [];
   _filteredItems = [];
   _authors = authors;
-  _searchForm = {};
-
   _currentFramework;
   _frameworks = {
     bulma: {
@@ -57,14 +51,33 @@ export class App {
     pageNumber: 0
   };
 
-  _searchFilter: Filter[];
+  _searchFilter: Filter[] = [
+    {
+      display: "Duration",
+      values: ["65", "45"],
+      fields: ["duration"]
+    }
+  ];
   _newSearchFilter: SearchFilters = {
-    duration: {
-      values: ["65", "45"]
+    Id: {
+      values: [],
+      fields: ["id"]
+    },
+    Title: {
+      values: [],
+      fields: ["title"]
+    },
+    Duration: {
+      values: ["65", "45"],
+      fields: ["duration"]
     },
     ["% Complete"]: {
       values: [],
       fields: ["percentComplete"]
+    },
+    ["Effort Driven"]: {
+      values: [],
+      fields: ["effortDriven"]
     },
     Author: {
       values: [],
@@ -72,20 +85,22 @@ export class App {
     }
   };
 
-  _itemColumns: ExtendedColumn[] = [
+  _itemColumns: Column[] = [
     {
       selection: true,
       renderer: ({ row }) => (row.selected ? "&#x2714;" : "")
     },
     {
-      field: "id"
+      field: "id",
+      header: "Id"
     },
     {
-      field: "title"
+      field: "title",
+      header: "Title"
     },
     {
       field: "duration",
-      filter: [65]
+      header: "Duration"
     },
     {
       field: "percentComplete",
@@ -99,10 +114,12 @@ export class App {
       }
     },
     {
-      field: "finish"
+      field: "finish",
+      header: "Finish"
     },
     {
-      field: "effortDriven"
+      field: "effortDriven",
+      header: "Effort Driven"
     },
     {
       field: ["author", "firstName"],
@@ -165,33 +182,27 @@ export class App {
         return {
           fields,
           display,
-          values: (this._searchForm[display] === null
-            ? []
-            : this._searchForm[display] || i.filter || i.values || []
+          values: (
+            (this._searchFilter.find(f => f.display === display) || {})
+              .values || []
           ).filter(v => v)
         } as Filter;
       });
 
-    this._searchForm = this._searchFilter.reduce((accu, curr) => {
-      accu[curr.display] = curr.values;
-
-      return accu;
-    }, {});
-  }
-
-  _refreshFilter(): void {
     this._newSearchFilter = {
       ...this._newSearchFilter
     };
   }
 
-  _filterRows(filteredItems: any[]): void {
-    this.rows = filteredItems.map((item, idx) => ({
+  _filterRows(detail: FilterEventDetail): void {
+    this.rows = detail.filteredItems.map((item, idx) => ({
       item,
       selectable: idx % 3 === 0 ? true : false
     }));
 
-    this._filteredItems = filteredItems;
+    this._filteredItems = detail.filteredItems;
+
+    this._searchFilter = detail.filter;
   }
 }
 

--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -6,6 +6,8 @@ interface ExtendedColumn extends Column {
   [x: string]: any;
 }
 
+type SearchFilters = import("resources").SearchFilters;
+
 const authors = ["John", "Ben", "Sam", "Tom", "Luke", "Ike", "Hayes", "Lee"];
 
 @inject("defaultOptions")
@@ -56,6 +58,19 @@ export class App {
   };
 
   _searchFilter: Filter[];
+  _newSearchFilter: SearchFilters = {
+    duration: {
+      values: ["65", "45"]
+    },
+    ["% Complete"]: {
+      values: [],
+      fields: ["percentComplete"]
+    },
+    Author: {
+      values: [],
+      fields: ["author", "firstName"]
+    }
+  };
 
   _itemColumns: ExtendedColumn[] = [
     {
@@ -164,6 +179,12 @@ export class App {
     }, {});
   }
 
+  _refreshFilter(): void {
+    this._newSearchFilter = {
+      ...this._newSearchFilter
+    };
+  }
+
   _filterRows(filteredItems: any[]): void {
     this.rows = filteredItems.map((item, idx) => ({
       item,
@@ -183,5 +204,15 @@ export class NumberValueConverter {
 
   fromView(value: string): number {
     return value === "" ? null : Number(value);
+  }
+}
+
+export class CsvValueConverter {
+  toView(value): string {
+    return !value ? "" : value.join(",");
+  }
+
+  fromView(value): any[] {
+    return !value ? [] : value.split(",");
   }
 }

--- a/dev-app/app.ts
+++ b/dev-app/app.ts
@@ -220,10 +220,10 @@ export class NumberValueConverter {
 
 export class CsvValueConverter {
   toView(value): string {
-    return !value ? "" : value.join(",");
+    return !Array.isArray(value) ? "" : value.join(",");
   }
 
-  fromView(value): any[] {
+  fromView(value): string[] {
     return !value ? [] : value.split(",");
   }
 }

--- a/dev-app/bootstrap3.html
+++ b/dev-app/bootstrap3.html
@@ -13,7 +13,7 @@
       <phd-search-bar
         filter.bind="_searchFilter"
         items.bind="allItems"
-        filtered.delegate="_filterRows($event.detail.filteredItems)"
+        filtered.delegate="_filterRows($event.detail)"
       >
         <div class="form-group">
           <label>Title</label>
@@ -21,7 +21,7 @@
             class="form-control"
             type="text"
             placeholder="Title"
-            value.bind="_searchForm.title[0]"
+            value.bind="_searchFilter[1].values | csv"
           />
         </div>
 
@@ -29,9 +29,9 @@
           <label>Duration</label>
           <input
             class="form-control"
-            type="number"
+            type="text"
             placeholder="Duration"
-            value.bind="_searchForm.duration[0] | number"
+            value.bind="_searchFilter[2].values | csv"
           />
         </div>
 
@@ -39,9 +39,9 @@
           <label>% Complete</label>
           <input
             class="form-control"
-            type="number"
+            type="text"
             placeholder="% Complete"
-            value.bind="_searchForm['% Complete'][0] | number"
+            value.bind="_searchFilter[3].values | csv"
           />
         </div>
 
@@ -51,7 +51,7 @@
             multiple
             size="4"
             class="form-control"
-            value.bind="_searchForm.Author"
+            value.bind="_searchFilter[7].values"
           >
             <option value="">Choose</option>
             <option value.bind="a" repeat.for="a of _authors">${a}</option>
@@ -59,7 +59,7 @@
         </div>
 
         <button class="button is-link" click.delegate="_resetFilter()">
-          Submit
+          Update
         </button>
       </phd-search-bar>
       <phd-table

--- a/dev-app/bulma.html
+++ b/dev-app/bulma.html
@@ -13,7 +13,7 @@
       <phd-search-bar
         filters.bind="_newSearchFilter"
         items.bind="allItems"
-        filtered.delegate="_filterRows($event.detail.filteredItems)"
+        filtered.delegate="_filterRows($event.detail)"
       >
         <div class="field">
           <label class="label">Title</label>
@@ -22,7 +22,7 @@
               class="input"
               type="text"
               placeholder="Title"
-              value.bind="_newSearchFilter.title.values"
+              value.bind="_newSearchFilter.Title.values | csv"
             />
           </div>
         </div>
@@ -34,7 +34,7 @@
               class="input"
               type="text"
               placeholder="Duration"
-              value.bind="_newSearchFilter.duration.values | csv"
+              value.bind="_newSearchFilter.Duration.values | csv"
             />
           </div>
         </div>
@@ -44,9 +44,9 @@
           <div class="control">
             <input
               class="input"
-              type="number"
+              type="text"
               placeholder="% Complete"
-              value.bind="_newSearchFilter['% Complete']"
+              value.bind="_newSearchFilter['% Complete'].values | csv"
             />
           </div>
         </div>
@@ -69,8 +69,8 @@
 
         <div class="field is-grouped">
           <div class="control">
-            <button class="button is-link" click.delegate="_refreshFilter()">
-              Submit
+            <button class="button is-link" click.delegate="_resetFilter()">
+              Update
             </button>
           </div>
         </div>

--- a/dev-app/bulma.html
+++ b/dev-app/bulma.html
@@ -11,7 +11,7 @@
   <div class="container">
     <div>
       <phd-search-bar
-        filter.bind="_searchFilter"
+        filters.bind="_newSearchFilter"
         items.bind="allItems"
         filtered.delegate="_filterRows($event.detail.filteredItems)"
       >
@@ -22,7 +22,7 @@
               class="input"
               type="text"
               placeholder="Title"
-              value.bind="_searchForm.title[0]"
+              value.bind="_newSearchFilter.title.values"
             />
           </div>
         </div>
@@ -32,9 +32,9 @@
           <div class="control">
             <input
               class="input"
-              type="number"
+              type="text"
               placeholder="Duration"
-              value.bind="_searchForm.duration[0] | number"
+              value.bind="_newSearchFilter.duration.values | csv"
             />
           </div>
         </div>
@@ -46,7 +46,7 @@
               class="input"
               type="number"
               placeholder="% Complete"
-              value.bind="_searchForm['% Complete'][0] | number"
+              value.bind="_newSearchFilter['% Complete']"
             />
           </div>
         </div>
@@ -55,7 +55,11 @@
           <label class="label">Author</label>
           <div class="control">
             <div class="select is-multiple">
-              <select multiple size="4" value.bind="_searchForm.Author">
+              <select
+                multiple
+                size="4"
+                value.bind="_newSearchFilter.Author.values"
+              >
                 <option value="">Choose</option>
                 <option value.bind="a" repeat.for="a of _authors">${a}</option>
               </select>
@@ -65,7 +69,7 @@
 
         <div class="field is-grouped">
           <div class="control">
-            <button class="button is-link" click.delegate="_resetFilter()">
+            <button class="button is-link" click.delegate="_refreshFilter()">
               Submit
             </button>
           </div>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "start": "au run",
     "watch": "au build-plugin --watch",
     "prepare": "npm run build",
-    "pretest": "au lint",
     "prettyup": "pretty-quick --staged",
     "preversion": "au test",
     "test": "au test",

--- a/src/elements/bootstrap3/phd-tags-input.html
+++ b/src/elements/bootstrap3/phd-tags-input.html
@@ -10,7 +10,7 @@
         ${t}
         <span
           class="input__icon--clickable"
-          click.trigger="_removeButtonClicked($index)"
+          click.trigger="_handleRemoveClick($index)"
         >
           &times;
         </span>
@@ -22,7 +22,7 @@
           placeholder="${placeholder}"
           value.bind="_newTagValue"
           type="text"
-          change.delegate="_inputChanged()"
+          change.delegate="_handleInputChange()"
           keydown.delegate="_handleKeydown($event)"
         />
       </slot>

--- a/src/elements/bulma/phd-search-bar.html
+++ b/src/elements/bulma/phd-search-bar.html
@@ -7,8 +7,8 @@
       <div class="control has-icons-left has-icons-right is-expanded">
         <phd-tags-input
           placeholder="New filter"
-          tag-removed.delegate="_removeFilter($event.detail)"
-          change.delegate="_tagAdded($event.target.value)"
+          tagdelete.delegate="_handleTagDelete($event.detail)"
+          tagpush.delegate="_handleTagPush($event.detail)"
           tags.bind="_tags"
         ></phd-tags-input>
         <span

--- a/src/elements/bulma/phd-tags-input.html
+++ b/src/elements/bulma/phd-tags-input.html
@@ -9,7 +9,7 @@
           ${t}
         </span>
         <a
-          click.delegate="_removeButtonClicked($index)"
+          click.delegate="_handleRemoveClick($index)"
           class="tag is-delete"
         ></a>
       </div>
@@ -21,7 +21,7 @@
         placeholder="${placeholder}"
         value.bind="_newTagValue"
         type="text"
-        change.delegate="_inputChanged()"
+        change.delegate="_handleInputChange()"
         keydown.delegate="_handleKeydown($event)"
       />
     </slot>

--- a/src/elements/phd-tags-input.ts
+++ b/src/elements/phd-tags-input.ts
@@ -1,9 +1,19 @@
 import { DOM, children } from "aurelia-framework";
 import { bindable } from "aurelia-templating";
 
+export interface TagChangeEventDetail {
+  index: number;
+  text: string;
+  value: string;
+  key: string;
+  relatedTags: string[];
+  relatedValues: string[];
+}
+
 export class PhdTagsInputCustomElement {
   @bindable placeholder = "New tag";
   @bindable tags = [];
+  @bindable separator = "=";
   @children(".tags-input__tag") _$controls: HTMLElement[] = [];
 
   _inputStyle: { [key: string]: string };
@@ -27,28 +37,22 @@ export class PhdTagsInputCustomElement {
     this.tags = this.tags || [];
   }
 
-  _removeButtonClicked(index): boolean {
-    const removedTag = this.tags.splice(index, 1);
+  _handleRemoveClick(index: number): boolean {
+    const removedTag = this.tags.splice(index, 1)[0];
 
-    this._$element.dispatchEvent(
-      DOM.createCustomEvent("tag-removed", {
-        bubbles: true,
-        detail: {
-          index,
-          text: removedTag[0]
-        }
-      })
-    );
+    const removedCancelled = this._emitEvent("tag-removed", index, removedTag);
+    const deleteCancelled = this._emitEvent("tagdelete", index, removedTag);
 
-    return true;
+    return removedCancelled && deleteCancelled;
   }
 
-  _inputChanged(): boolean {
+  _handleInputChange(): boolean {
     if (this._newTagValue) {
       this.tags.push(this._newTagValue);
 
+      this._emitEvent("tagpush", this.tags.length - 1, this._newTagValue);
+
       this._newTagValue = null;
-      return true;
     }
 
     return false;
@@ -83,5 +87,32 @@ export class PhdTagsInputCustomElement {
     }
 
     return true;
+  }
+
+  _emitEvent(type: string, index: number, tag: string): boolean {
+    const getKey = (term: string): string => {
+      return !term.split(this.separator)[1]
+        ? ""
+        : term.split(this.separator)[0];
+    };
+    const getValue = (term: string): string =>
+      term.split(this.separator)[1] || term.split(this.separator)[0];
+    const tagKey = getKey(tag);
+    const relatedTags = this.tags.filter(t => getKey(t) === tagKey);
+    const eventDetail: TagChangeEventDetail = {
+      index,
+      text: tag,
+      value: getValue(tag).trim(),
+      key: tagKey,
+      relatedTags,
+      relatedValues: relatedTags.map(t => getValue(t))
+    };
+
+    return this._$element.dispatchEvent(
+      DOM.createCustomEvent(type, {
+        bubbles: true,
+        detail: eventDetail
+      })
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@ import "./styles.css";
 import * as framework from "./elements/index";
 
 export * from "./model";
-export { FilterEventDetail, Filter, SearchFilters, SearchFilter } from "./elements/phd-search-bar";
+export {
+  FilterEventDetail,
+  Filter,
+  SearchFilters,
+  SearchFilter
+} from "./elements/phd-search-bar";
 export { TagChangeEventDetail } from "./elements/phd-tags-input";
 export { Model as NavbarModel } from "./elements/phd-navbar";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import "./styles.css";
 import * as framework from "./elements/index";
 
 export * from "./model";
-export { FilterEventDetail, Filter } from "./elements/phd-search-bar";
+export { FilterEventDetail, Filter, SearchFilters, SearchFilter } from "./elements/phd-search-bar";
+export { TagChangeEventDetail } from "./elements/phd-tags-input";
 export { Model as NavbarModel } from "./elements/phd-navbar";
 
 interface PluginOptions {

--- a/test/unit/elements/phd-tags-input.spec.ts
+++ b/test/unit/elements/phd-tags-input.spec.ts
@@ -1,0 +1,197 @@
+import { bootstrap } from "aurelia-bootstrapper";
+import { StageComponent } from "aurelia-testing";
+import { PLATFORM, DOM } from "aurelia-pal";
+import frameworks from "../frameworks";
+
+type ComponentTester = import("aurelia-testing").ComponentTester;
+
+interface BindOptions {
+  bindables: Record<string, any>;
+  delegates: Record<string, string>;
+  handlers: Record<string, Function>;
+}
+
+function bind(
+  component: ComponentTester,
+  attributes?: string,
+  context?: Record<string, any>
+): ComponentTester {
+  return component
+    .inView(`<phd-tags-input ${attributes}}></phd-tags-input>`)
+    .boundTo({ ...context });
+}
+
+frameworks.forEach(framework => {
+  describe("The tags input custom element", () => {
+    let component: ComponentTester;
+
+    beforeEach(() => {
+      component = StageComponent.withResources([
+        PLATFORM.moduleName("elements/phd-tags-input")
+      ]);
+
+      component.bootstrap(aurelia => {
+        return aurelia.use
+          .standardConfiguration()
+          .feature(PLATFORM.moduleName("resources"), { framework });
+      });
+    });
+
+    afterEach(() => component.dispose());
+
+    xit("adjusts the input style on attached", () => {});
+
+    xit("adjusts the input style if the control element changes", () => {});
+
+    it("creates no tags when none are bound", async () => {
+      await bind(component).create(bootstrap);
+
+      const $tags = component.element.querySelector(".tags-input__tag");
+
+      expect($tags).toEqual(null);
+    });
+
+    describe("when tags are bound", () => {
+      beforeEach(async () => {
+        await bind(component, `tags.bind="tags"`, {
+          tags: ["foo", "bar"]
+        }).create(bootstrap);
+      });
+
+      it("creates tags when they are bound", async () => {
+        const $tags = await component.waitForElements(".tags-input__tag");
+
+        expect($tags.length).toEqual(2);
+      });
+
+      // bulma specific
+      it("shows the tags text", async () => {
+        const $tags = await component.waitForElements(".tags-input__tag");
+
+        expect(Array.from($tags).map(t => t.textContent.trim())).toContain(
+          "foo"
+        );
+      });
+
+      // bulma specific
+      it("removes the tags when delete button clicked", async done => {
+        const $deleteLink = (await component.waitForElement(
+          ".tags-input__tag a"
+        )) as HTMLAnchorElement;
+
+        $deleteLink.click();
+
+        setTimeout(() => {
+          const $tags = component.element.querySelectorAll(".tags-input__tag");
+          expect($tags.length).toEqual(1);
+          done();
+        });
+      });
+    });
+
+    ["tag-removed", "tagdelete"].forEach(event => {
+      it("emits a tag-removed event on tag removed", async () => {
+        let tagRemovedEvent = null;
+        await bind(
+          component,
+          `tags.bind="tags" ${event}.delegate="tagRemoved($event)"`,
+          {
+            tags: ["foo", "bar"],
+            tagRemoved: event => (tagRemovedEvent = event)
+          }
+        ).create(bootstrap);
+        const $deleteLink = (await component.waitForElement(
+          ".tags-input__tag a"
+        )) as HTMLAnchorElement;
+
+        $deleteLink.click();
+
+        expect(tagRemovedEvent.detail).toEqual({
+          index: 0,
+          text: "foo",
+          value: "foo",
+          key: "",
+          relatedTags: ["bar"],
+          relatedValues: ["bar"]
+        });
+      });
+
+      xit("prevents default if events are cancelled", async done => {});
+    });
+
+    it("emits a tagpush event when a new value is entered", async done => {
+      let tagAddedEvent = null;
+      await bind(component, `tagpush.delegate="tagAdded($event)"`, {
+        tagAdded: event => (tagAddedEvent = event)
+      }).create(bootstrap);
+      const $input = (await component.waitForElement(
+        ".tags-input__input"
+      )) as HTMLInputElement;
+
+      $input.value = "foobar";
+
+      $input.dispatchEvent(DOM.createCustomEvent("change", { bubbles: true }));
+
+      setTimeout(() => {
+        expect(tagAddedEvent.detail).toEqual({
+          index: 0,
+          text: "foobar",
+          value: "foobar",
+          key: "",
+          relatedTags: ["foobar"],
+          relatedValues: ["foobar"]
+        });
+        done();
+      });
+    });
+
+    it("supports a key value pair when entered", async done => {
+      let tagAddedEvent = null;
+      await bind(component, `tagpush.delegate="tagAdded($event)"`, {
+        tagAdded: event => (tagAddedEvent = event)
+      }).create(bootstrap);
+      const $input = (await component.waitForElement(
+        ".tags-input__input"
+      )) as HTMLInputElement;
+
+      $input.value = "foo=bar";
+
+      $input.dispatchEvent(DOM.createCustomEvent("change", { bubbles: true }));
+
+      setTimeout(() => {
+        expect(tagAddedEvent.detail).toEqual({
+          index: 0,
+          text: "foo=bar",
+          value: "bar",
+          key: "foo",
+          relatedTags: ["foo=bar"],
+          relatedValues: ["bar"]
+        });
+        done();
+      });
+    });
+
+    it("does not emit a tagpush event when the new value entered is missing", async done => {
+      let tagAddedEvent = null;
+      await bind(component, `tagpush.delegate="tagAdded($event)"`, {
+        tagAdded: event => (tagAddedEvent = event)
+      }).create(bootstrap);
+      const $input = (await component.waitForElement(
+        ".tags-input__input"
+      )) as HTMLInputElement;
+
+      $input.value = "";
+
+      $input.dispatchEvent(DOM.createCustomEvent("change", { bubbles: true }));
+
+      setTimeout(() => {
+        expect(tagAddedEvent).toEqual(null);
+        done();
+      });
+    });
+
+    xit("removes the input text on ESC", async done => {});
+
+    xit("does nothing on tab", async done => {});
+  });
+});

--- a/test/unit/frameworks.ts
+++ b/test/unit/frameworks.ts
@@ -1,0 +1,3 @@
+const frameworks = ["bulma"];
+
+export default frameworks;


### PR DESCRIPTION
* Create a bindable filter object that has the display name of the
    filter as the property key and any extra fields in the object. Make
    it easier to integrate with the tags, any search form used in the
    slot and to ensure the display fields are kept unique. Keep the old
    filters array until deprecated. Show the new filter in the bulma
    demo, but keep the old filter in the bootstrap3 to ensure backwards
    compatibility.
* Add first tests to ensure tags are backwards compatible too, and now
    do the heavy lifting of parsing the tags. Support a
    keyvalue format to store structure objects. This will allow
    us to [eventually] store other data in bindable tags property
    instead of making it a string that we parse.

fixes [AB#4711](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4711)